### PR TITLE
Update calendar-widget.js

### DIFF
--- a/resources/js/calendar-widget.js
+++ b/resources/js/calendar-widget.js
@@ -277,7 +277,7 @@ export default function calendarWidget({
                 };
             }
 
-            this.ec = EventCalendar.create(this.$el.querySelector('div'), {
+            this.ec = window.EventCalendar.create(this.$el.querySelector('div'), {
                 ...settings,
                 ...options
             });


### PR DESCRIPTION
Context:
The error occurred because EventCalendar is not available as a global constructor. When loaded via CDN, it must be accessed through window.EventCalendar.

Changes made:

Updated the initialization in calendar-widget.js to use window.EventCalendar instead of referencing EventCalendar directly.

This ensures proper access to the constructor when the script is loaded from a CDN, avoiding runtime errors.

Expected outcome:
The calendar should now initialize correctly in environments where the script is served from a CDN.