### PR TITLE
fix: allow the hiding of the footer in the widget

### DIFF
--- a/resources/views/widgets/calendar-widget.blade.php
+++ b/resources/views/widgets/calendar-widget.blade.php
@@ -8,7 +8,7 @@
 <x-filament-widgets::widget>
     <x-filament::section
         :after-header="$this->getCachedHeaderActionsComponent()"
-        :footer="$this->getCachedFooterActionsComponent()"
+        :footer="$this->showFooter ? $this->getCachedFooterActionsComponent() : null"
     >
 
         <style>

--- a/src/Filament/CalendarWidget.php
+++ b/src/Filament/CalendarWidget.php
@@ -15,4 +15,6 @@ abstract class CalendarWidget extends Widget implements HasActions, HasCalendar,
     protected string $view = 'guava-calendar::widgets.calendar-widget';
 
     protected int | string | array $columnSpan = 'full';
+
+    protected bool $showFooter = true;
 }


### PR DESCRIPTION
Currently there is no way to hide the footer part of the section, even if the footer is empty. This results in a double-border at the bottom, not looking so good. This PR includes a simple remedy by allowing the developer to add the following 
to their widget.
```php
public bool $showFooter = false;
```

Before:

<img width="2906" height="206" alt="CleanShot 2025-11-09 at 16 20 57@2x" src="https://github.com/user-attachments/assets/0e73ee62-1688-4eed-84ca-932ac7c8d414" />


After:

<img width="2886" height="148" alt="CleanShot 2025-11-09 at 16 43 14@2x" src="https://github.com/user-attachments/assets/18bef4ef-b4f8-484e-9375-e30ae80fd96f" />

