### PR TITLE
Adding support for Htmlable's in the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,14 @@ Sets the title of the event that is rendered in the calendar.
 CalendarEvent::make()->title('My event');
 ```
 
+To output Html in the title pass in a `HtmlString` or other class that implements `Htmlable` :
+
+```php
+CalendarEvent::make()
+->title(new HtmlString('<b>My Event</b>'));
+```
+
+
 #### Customizing the start/end date
 Sets the start or end date (and time) of the calendar in the calendar.
 ```php

--- a/src/ValueObjects/CalendarEvent.php
+++ b/src/ValueObjects/CalendarEvent.php
@@ -4,15 +4,17 @@ namespace Guava\Calendar\ValueObjects;
 
 use Carbon\Carbon;
 use Filament\Support\Facades\FilamentTimezone;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 use function Guava\Calendar\utc_to_user_local_time;
+use function Pest\Laravel\instance;
 
 class CalendarEvent
 {
-    protected string $title;
+    protected string|Htmlable $title;
 
     protected Carbon $start;
 
@@ -94,14 +96,14 @@ class CalendarEvent
         return $this->allDay;
     }
 
-    public function title(string $title): static
+    public function title(string|Htmlable $title): static
     {
         $this->title = $title;
 
         return $this;
     }
 
-    public function getTitle(): string
+    public function getTitle(): string|Htmlable
     {
         return $this->title;
     }
@@ -312,7 +314,7 @@ class CalendarEvent
     public function toCalendarObject(int $timezoneOffset, bool $useFilamentTimezone): array
     {
         $array = [
-            'title' => $this->getTitle(),
+            'title' => $this->getTitle() instanceof Htmlable ? ['html' => $this->getTitle()->toHtml()] : $this->getTitle(),
             'start' => $useFilamentTimezone
                 ? $this->getStart()->setTimezone(FilamentTimezone::get())->toIso8601String()
                 : $this->getStart()->utcOffset($timezoneOffset)->toIso8601String(),

--- a/tests/Unit/ValueObjects/EventTest.php
+++ b/tests/Unit/ValueObjects/EventTest.php
@@ -31,6 +31,13 @@ it('should set the title', function () {
     expect($this->event->getTitle())->toBe($title);
 });
 
+it('should set the html title', function () {
+    $title = new Illuminate\Support\HtmlString('<strong>Test Event</strong>');
+    $this->event->title($title);
+
+    expect($this->event->getTitle())->toBe($title);
+});
+
 it('should set the background color', function () {
     $color = '#ff0000';
     $this->event->backgroundColor($color);
@@ -126,4 +133,30 @@ it('should return props to array', function () {
         'resourceIds' => $resourceIds,
         'extendedProps' => $extendedProps,
     ]);
+});
+
+
+
+it('should return title with string', function () {
+    $title = 'Test Event';
+
+    $this->event->title($title)->start(Carbon::now())->end(Carbon::now()->addHour());
+
+    expect($this->event->toCalendarObject(0, false))
+        ->toMatchArray([
+            'title' => 'Test Event',
+        ]);
+});
+
+it('should return html props with htmlable', function () {
+    $title = new Illuminate\Support\HtmlString('<strong>Test Event</strong>');
+
+    $this->event->title($title)->start(Carbon::now())->end(Carbon::now()->addHour());
+
+    expect($this->event->toCalendarObject(0, false))
+        ->toMatchArray([
+            'title' => [
+                'html' => '<strong>Test Event</strong>',
+            ]
+        ]);
 });


### PR DESCRIPTION
To fix #102 this outputs any htmlable in the title as a html object per [vkuko/calendar content](https://github.com/vkurko/calendar?tab=readme-ov-file#content).

```php
CalendarEvent::make()
->title(new HtmlString('<b>My Event</b>'));
```

Strings will need to be wrapped in HtmlString to render as this ensures compatibility with current string usage and provides a level of security/developer intention where user strings cannot be interpreted as Html unexpectedly. 

I've used the `Htmlable` interface so a view could be used if desired, but only tested with Htmlstring.