### PR TITLE
feat: enhance dark theme styles with additional color variables

### DIFF
--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -14,6 +14,16 @@
     --ec-button-active-text-color: var(--hover-text);
 }
 .dark .ec {
+    color-scheme: dark;
+    --ec-color-400: oklch(43.9% 0 0);
+    --ec-color-300: oklch(37.1% 0 0);
+    --ec-color-200: oklch(26.9% 0 0);
+    --ec-color-100: oklch(20.5% 0 0);
+    --ec-color-50: oklch(14.5% 0 0);
+    --ec-bg-color: var(--gray-900);
+    --ec-highlight-color: oklch(30.2% 0.056 229.695);
+    --ec-bg-event-opacity: 0.5;
+
     --ec-list-day-bg-color: var(--gray-900);
     --ec-today-bg-color: color-mix(in oklab, var(--color-500) 20%, transparent);
 


### PR DESCRIPTION
Fix for #145 
This pull request adds several new CSS custom properties to improve the color theming for dark mode in the application. The main focus is on defining a more consistent and customizable color palette for elements in dark mode.

Dark mode theming improvements:

* Added `color-scheme: dark` and defined new `--ec-color-*` variables (`--ec-color-400`, `--ec-color-300`, `--ec-color-200`, `--ec-color-100`, `--ec-color-50`) using the `oklch` color model for better color consistency in dark mode.
* Introduced `--ec-bg-color`, `--ec-highlight-color`, and `--ec-bg-event-opacity` variables to allow more flexible background and highlight styling in dark mode.