### PR TITLE
fix: preserve timezone in fromCalendarObject via Carbon::instance()

### DIFF
--- a/src/ValueObjects/CalendarEvent.php
+++ b/src/ValueObjects/CalendarEvent.php
@@ -366,8 +366,8 @@ class CalendarEvent
         }
         $this
             ->title($title)
-            ->start(utc_to_user_local_time($data['start'], $timezoneOffset, $useFilamentTimezone))
-            ->end(utc_to_user_local_time($data['end'], $timezoneOffset, $useFilamentTimezone))
+            ->start(Carbon::instance(utc_to_user_local_time($data['start'], $timezoneOffset, $useFilamentTimezone)))
+            ->end(Carbon::instance(utc_to_user_local_time($data['end'], $timezoneOffset, $useFilamentTimezone)))
             ->allDay($data['allDay'])
             ->styles($data['styles'])
             ->classNames($data['classNames'])


### PR DESCRIPTION
## Problem

When `useFilamentTimezone` is enabled and the browser is not in UTC, event drag-and-drop and resize operations receive incorrect times. Resize is particularly affected — events snap back to their original position.

## Root Cause

`utc_to_user_local_time()` (in `helpers.php`) correctly returns a `CarbonImmutable` with the intended timezone (e.g., `14:00 Africa/Johannesburg`). However, `CalendarEvent::start()` accepts `string | Carbon`:

```php
public function start(string | Carbon $start): static
```

`CarbonImmutable` is neither `string` nor `Carbon` (they're sibling classes — `Carbon` extends `DateTime`, `CarbonImmutable` extends `DateTimeImmutable`). PHP's type coercion silently converts via `__toString()`:

```
CarbonImmutable("14:00 Africa/Johannesburg")
  → __toString() → "2026-04-07 14:00:00"       // timezone lost
  → Carbon::make() → Carbon("14:00 UTC")        // recreated in app timezone
```

This means `$info->event->getStart()` and `$info->event->getEnd()` in `EventDropInfo` / `EventResizeInfo` return times with the wrong timezone.

### Why drag-and-drop sometimes appears to work

If the consumer re-parses the time string in the correct timezone (e.g., extracting `format('H:i')` and parsing it back with the calendar timezone), the error is accidentally compensated. But consumers that use the Carbon object directly — like resize operations calling `->utc()` — get wrong results because the timezone is already incorrectly labelled as UTC.

### Why this hasn't been widely reported

With `tzOffset=0` (UTC browser) or when `useFilamentTimezone=false`, `utc_to_user_local_time` is effectively a no-op, so the coercion causes no harm. The bug only surfaces in multi-timezone setups — consistent with the reports in #89, #38, and discussion #74.

## Fix

Wrap the `CarbonImmutable` output with `Carbon::instance()` in `fromCalendarObject()` — the one internal point where the immutable helper connects to the mutable setter:

```php
// Before:
->start(utc_to_user_local_time($data['start'], $timezoneOffset, $useFilamentTimezone))
->end(utc_to_user_local_time($data['end'], $timezoneOffset, $useFilamentTimezone))

// After:
->start(Carbon::instance(utc_to_user_local_time($data['start'], $timezoneOffset, $useFilamentTimezone)))
->end(Carbon::instance(utc_to_user_local_time($data['end'], $timezoneOffset, $useFilamentTimezone)))
```

`Carbon::instance()` converts `CarbonImmutable` → mutable `Carbon` while **preserving the timezone**.

## Design considerations

This fix was scoped to respect the existing design choices:

- **`start()` / `end()` signatures unchanged** — The public API accepting `string | Carbon` is correct for consumers who pass Eloquent `datetime` casts (always mutable `Carbon`). No signature or return type changes.
- **`utc_to_user_local_time()` still returns `CarbonImmutable`** — Immutable is the right choice for a pure conversion helper. The fix converts at the boundary, not in the helper.
- **Mutable `Carbon` for the value object preserved** — `toCalendarObject()` relies on `setTimezone()` mutating in place via the method chain. This continues to work as before.
- **The existing `EventTest` passes** — The test at `tests/Unit/ValueObjects/EventTest.php` passes `Carbon` (mutable) to `start()` and checks identity with `toBe()`. Since the fix only affects the `fromCalendarObject` path (which receives `CarbonImmutable` from the helper), existing tests are unaffected.

## Verification

Tested in a Laravel 12 + Filament 5 application with:
- Organization timezone: `Africa/Johannesburg` (UTC+2)
- FilamentTimezone set via `FilamentTimezone::set(fn () => Organization::timezone())`
- Browser simulated at `tzOffset=120` with `useFilamentTimezone=true`

| Scenario | Drag-drop | Resize |
|---|---|---|
| **Without fix** | Passes (accidental self-correction) | **Fails** (off by tz offset) |
| **With fix** | Passes | Passes |

Relates to #89, #38, and discussion #74.