### PR TITLE
fix: drop empty trailing div from context menu blade

### DIFF
--- a/resources/views/components/context-menu.blade.php
+++ b/resources/views/components/context-menu.blade.php
@@ -34,27 +34,5 @@
             {{--                        {{ $action }}--}}
             {{--                    @endforeach--}}
         </x-filament::dropdown.list>
-        <div>
-            {{--                <x-filament::dropdown.list x-show="context == '{{Context::DateClick}}'">--}}
-            {{--                    @foreach ($dateClickContextMenuActions as $action)--}}
-            {{--                        {{ $action }}--}}
-            {{--                    @endforeach--}}
-            {{--                </x-filament::dropdown.list>--}}
-            {{--                <x-filament::dropdown.list x-show="context == '{{Context::DateSelect}}'">--}}
-            {{--                    @foreach ($dateSelectContextMenuActions as $action)--}}
-            {{--                        {{ $action }}--}}
-            {{--                    @endforeach--}}
-            {{--                </x-filament::dropdown.list>--}}
-            {{--            <x-filament::dropdown.list>--}}
-            {{--                @foreach ($eventClickContextMenuActions as $action)--}}
-            {{--                    {{ $action }}--}}
-            {{--                @endforeach--}}
-            {{--            </x-filament::dropdown.list>--}}
-            {{--                <x-filament::dropdown.list x-show="context == '{{Context::NoEventsClick}}'">--}}
-            {{--                    @foreach ($noEventsClickContextMenuActions as $action)--}}
-            {{--                        {{ $action }}--}}
-            {{--                    @endforeach--}}
-            {{--                </x-filament::dropdown.list>--}}
-        </div>
     </div>
 </div>


### PR DESCRIPTION
## Problem

The trailing `<div>` in `resources/views/components/context-menu.blade.php` contains only commented-out Blade markup (lines 37-58 — old per-context dropdown lists, now superseded by the `<template x-for="action in actions">` loop). At render time the comments are stripped and the wrapper renders as an empty `<div>`.

The parent panel uses Tailwind's `divide-y`, which translates to a `border-top` on every direct child after the first. The empty trailing `<div>` therefore picks up a divider that paints just below the  dropdown list, **outside** the rounded panel — visible as a stray horizontal line below the menu.

## Fix

Remove the empty `<div>` block. The `<template x-for="action in actions">` loop already covers every context (DateClick, DateSelect, EventClick, NoEventsClick) since the actions collection is filtered per-context by `HasContextMenu::getContextMenuActionsUsing()` upstream of the view.    

## Verification
Tested on Filament v4 + Tailwind v4. The dropdown panel now ends cleanly at the last action item; no functional regression in the four context scenarios.
