### PR TITLE
Allow getTitle to return Htmlable type

### DIFF
--- a/src/ValueObjects/CalendarResource.php
+++ b/src/ValueObjects/CalendarResource.php
@@ -40,7 +40,7 @@ class CalendarResource
         return $this;
     }
 
-    public function getTitle(): string
+    public function getTitle(): string | Htmlable
     {
         return $this->title;
     }


### PR DESCRIPTION
Missed this in my original PR: https://github.com/GuavaCZ/calendar/pull/137